### PR TITLE
Clear up implementation of seed

### DIFF
--- a/db/migrate/1458059593_add_limit_seed_to_runs.rb
+++ b/db/migrate/1458059593_add_limit_seed_to_runs.rb
@@ -1,0 +1,8 @@
+class AddLimitSeedToRuns < ActiveRecord::Migration
+
+  def change
+    add_column :runs, :seed,  :integer, limit: 4
+    add_column :runs, :limit, :integer, limit: 6
+  end
+
+end

--- a/lib/models/run.rb
+++ b/lib/models/run.rb
@@ -16,6 +16,10 @@ class Run < ActiveRecord::Base
     placements.where(position: nil)
   end
 
+  def sql_seed
+    seed / 10_000.to_f
+  end
+
   def running!
     self.update_attribute(:status, :running)
   end

--- a/lib/tasks/lottery.rake
+++ b/lib/tasks/lottery.rake
@@ -7,13 +7,13 @@ namespace :lottery do
   end
 
   desc 'Runs the matching process.'
-  task :run, [:limit] => :environment do |t, args|
+  task :run, [:limit, :seed] => :environment do |t, args|
     $logger.debug "----> Running task `lottery:run` in #{DATABASE_ENV} environment."
     $logger.info '----> Running checks first'
     Rake::Task['lottery:check'].invoke
     begin
       $logger.info '----> Starting match!'
-      id = MatchJob.new(args[:limit]).perform!
+      id = MatchJob.new(limit: args[:limit], seed: args[:seed]).perform!
       Rake::Task['lottery:stats'].invoke(id)
       # TODO: Move to controller action
       # Rake::Task['lottery:export'].invoke(id)
@@ -21,6 +21,7 @@ namespace :lottery do
     rescue StandardError => e
       $logger.error '----> FAIL: Task errored out.'
       $logger.error "----> #{e.message}"
+      $logger.error e.backtrace.join("\n")
       exit 1
     end
   end

--- a/test/models/run_test.rb
+++ b/test/models/run_test.rb
@@ -3,7 +3,7 @@ require 'test_helper'
 class RunTest < Minitest::Test
 
   def setup
-    @run = Run.create!
+    @run = Run.create!(limit: 10, seed: 1000)
   end
 
   def teardown
@@ -27,12 +27,19 @@ class RunTest < Minitest::Test
     assert_equal 'succeeded', @run.status
   end
 
-  def test_run_performs_match_job
-    skip 'Does performing the job get done by a collaborator?'
+  def test_limit
+    assert_respond_to @run, :limit
+    assert_equal 10, @run.limit
   end
 
-  def test_generates_stats_after_run
-    skip 'Could be another object that does this'
+  def test_seed
+    assert_respond_to @run, :seed
+    assert_equal 1000, @run.seed
+  end
+
+  def test_sql_seed
+    assert_respond_to @run, :sql_seed
+    assert_equal 0.1000, @run.sql_seed
   end
 
 end


### PR DESCRIPTION
Why:

Seed methods were getting scattered throughout MatchJob, and the limit
and seed are data points that should be stored as information about the
run.

It's nicer to see seed as a 4- or 5-digit integer, but SQL needs a
decimal.

This change addresses the need by:

* Adding seed, limit fields to run.

* Adding #sql_seed method to convert to a decimal.