### PR TITLE
Clean up relay, delegate placement queries to Placement

### DIFF
--- a/apps/relay.rb
+++ b/apps/relay.rb
@@ -1,17 +1,19 @@
 require 'sinatra/base'
 require 'sinatra/activerecord'
 require './environment'
-# require 'airbrake'
+require 'airbrake'
 
 class Apps::Relay < Sinatra::Base
 
-  # Airbrake.configure do |c|
-  #   c.project_id  = ENV['AIRBRAKE_ID']
-  #   c.project_key = ENV['AIRBRAKE_KEY']
-  #   c.environment = ENV['DATABASE_ENV']
-  #   c.ignore_environments = %w( development test )
-  #   c.logger.level = Logger::DEBUG
-  # end
+  if ENV['AIRBRAKE_ID']
+    Airbrake.configure do |c|
+      c.project_id  = ENV['AIRBRAKE_ID']
+      c.project_key = ENV['AIRBRAKE_KEY']
+      c.environment = ENV['DATABASE_ENV']
+      c.ignore_environments = %w( development test )
+      c.logger.level = Logger::DEBUG
+    end
+  end
 
   set :method_override, true
   set :logger, $stdout
@@ -21,8 +23,6 @@ class Apps::Relay < Sinatra::Base
   end
 
   get '/placements/:id/accept/?' do
-    puts "ACCEPT PARAMS: #{params.inspect}"
-    puts "ACCEPT REQUEST: #{request.inspect}"
     load_placement(params)
     @placement.accepted
     redirect *DYEERedirect.to(:accept)
@@ -42,26 +42,22 @@ class Apps::Relay < Sinatra::Base
   end
 
   error ActiveRecord::RecordNotFound do
-    # Airbrake.notify('Record Not Found', params: params)
-    puts "NotFound PARAMS: #{params.inspect}"
+    Airbrake.notify('Record Not Found', params: params)
     redirect *DYEERedirect.to(:error)
   end
 
   error 404 do
-    # Airbrake.notify('404 / Record Not Found', params: params)
-    puts "404 PARAMS: #{params.inspect}"
+    Airbrake.notify('404 / Record Not Found', params: params)
     redirect *DYEERedirect.to(:error)
   end
 
   error 422 do
-    # Airbrake.notify('Unprocessable Entity', params: params)
-    puts "422 PARAMS: #{params.inspect}"
+    Airbrake.notify('Unprocessable Entity', params: params)
     redirect *DYEERedirect.to(:error)
   end
 
   error 500 do
-    # Airbrake.notify('Internal Server Error', params: params)
-    puts "500 PARAMS: #{params.inspect}"
+    Airbrake.notify('Internal Server Error', params: params)
     redirect *DYEERedirect.to(:error)
   end
 

--- a/lib/jobs/lottery_run_job.rb
+++ b/lib/jobs/lottery_run_job.rb
@@ -2,7 +2,7 @@ class LotteryRunJob
 
   def initialize(run_id: , limit: nil)
     @run = Run.find(run_id)
-    #  TODO: Update config from file.
+    # TODO: Update config from file.
     @limit = limit # Don't convert to integer, to let nil be nil.
   end
 
@@ -16,8 +16,8 @@ class LotteryRunJob
 
   def perform
     total_positions = Position.sum(:automatic)
-    @run.actionable_placement_ids(limit: @limit).each do |placement_id|
-      log_placement Placement.find(placement_id).place!
+    @run.placeable_placements(limit: @limit).each do |placement|
+      log_placement placement.place!
       break unless @run.exportable_placements.count < total_positions
     end
   end
@@ -27,7 +27,7 @@ class LotteryRunJob
   end
 
   def log_start
-    count = @run.actionable_placement_ids(limit: @limit).count
+    count = @run.placeable_placements(limit: @limit).count
     msg = "Starting to place #{count} applicants for Run ##{@run.id}"
     msg << " (Given a limit of #{@limit}.)" if @limit
     $logger.info msg

--- a/lib/models/applicant.rb
+++ b/lib/models/applicant.rb
@@ -6,12 +6,23 @@ class Applicant < ActiveRecord::Base
   include Locatable
   include CreatableFromICIMS
 
+  # Hack for the moment. Should override locatable delegation.
+  def zip
+    if addresses.first
+      addresses.first.fetch('zip', '')
+    end
+  end
+
   extend Enumerize
 
   has_many :placements
 
   def placements_for_run(run)
     run.placements.where(applicant_id: id)
+  end
+
+  def self.eligible_for_lottery
+    random.where.not grid_id: nil
   end
 
   before_validation :compute_grid_id, if: 'location.present?'

--- a/lib/models/icims/address.rb
+++ b/lib/models/icims/address.rb
@@ -18,7 +18,7 @@ class ICIMS::Address
   end
 
   def street
-    str = @address.fetch('addressstreet1')
+    str = @address.fetch('addressstreet1', '')
     if street2 = @address.fetch('addressstreet2', false)
       str << ' ' + street2
     end
@@ -29,17 +29,15 @@ class ICIMS::Address
   end
 
   def city
-    @address.fetch('addresscity')
+    @address.fetch('addresscity', '')
   end
 
   def state
-    @address.
-      fetch('addressstate', {}).
-      fetch('abbrev', 'MA')
+    @address.fetch('addressstate', {'abbrev' => 'MA'}).fetch('abbrev')
   end
 
   def zip
-    @address.fetch('addresszip')
+    @address.fetch('addresszip', '')
   end
 
   def to_s

--- a/lib/models/position.rb
+++ b/lib/models/position.rb
@@ -49,7 +49,7 @@ class Position < ActiveRecord::Base
   end
 
   def check_availability(run)
-    if automatic > taken_placements(run).count
+    if !automatic.nil? && automatic > taken_placements(run).count
       run.add_to_available self
     else
       run.remove_from_available self

--- a/lib/tasks/export.rake
+++ b/lib/tasks/export.rake
@@ -48,6 +48,45 @@ namespace :export do
     end
   end
 
+  desc 'Export applicants for allocation'
+  task appall: :environment do |t, args|
+    pre_message(t)
+    file = "./tmp/exports/applicants-#{Time.now.to_i}.csv"
+    CSV.open(file, 'wb') do |csv|
+      fields = %w( uuid zip prefers_nearby has_transit_pass interests )
+      csv << fields
+      fields.pop # Remove interests
 
+      Applicant.find_each do |applicant|
+        begin
+          interests = applicant.interests.join(';')
+          attrs = fields.map { |field| applicant.send(field) }
+          attrs.push interests # Add interests to end
+          csv << attrs
+        rescue StandardError => e
+          puts "----> #{applicant.id}: #{e.message}"
+          next
+        end
+      end
+    end
+  end
+
+  desc 'Export applicants for allocation'
+  task posall: :environment do |t, args|
+    pre_message(t)
+    file = "./tmp/exports/positions-#{Time.now.to_i}.csv"
+    CSV.open(file, 'wb') do |csv|
+      fields = %w( uuid positions automatic manual zip_5 category reserve )
+      csv << fields
+      Position.find_each do |position|
+        begin
+          csv << fields.map { |field| position.send(field) }
+        rescue StandardError => e
+          puts "----> #{position.id}: #{e.message}"
+          next
+        end
+      end
+    end
+  end
 
 end

--- a/lib/tasks/export.rake
+++ b/lib/tasks/export.rake
@@ -53,7 +53,7 @@ namespace :export do
     pre_message(t)
     file = "./tmp/exports/applicants-#{Time.now.to_i}.csv"
     CSV.open(file, 'wb') do |csv|
-      fields = %w( uuid zip prefers_nearby has_transit_pass interests )
+      fields = %w( id uuid zip prefers_nearby has_transit_pass interests )
       csv << fields
       fields.pop # Remove interests
 

--- a/test/apps/relay_test.rb
+++ b/test/apps/relay_test.rb
@@ -10,12 +10,12 @@ class RelayTest < Minitest::Test
 
   def setup
     @run = Run.create!
-    @position  = Position.create!(uuid: "1c48f911-28ac-4e3b-86df-ace38e8092bd")
-    @applicant = Applicant.create!(uuid: "c4e12e70-52a5-4014-9990-7238627f37d7")
+    @position  = Position.create!(id: 7777,  uuid: "1c48f911-28ac-4e3b-86df-ace38e8092bd")
+    @applicant = Applicant.create!(id: 7777, uuid: "c4e12e70-52a5-4014-9990-7238627f37d7")
     @placement = @run.placements.create!(
       uuid: "f95bfae2-cfb3-4185-aeef-249792502e4d",
-      applicant: @applicant,
-      position: @position,
+      applicant_id: @applicant.id,
+      position_id: @position.id,
       run: @run, index: 1,
       workflow_id: 19288,
       market: :automatic

--- a/test/lib/statuses_test.rb
+++ b/test/lib/statuses_test.rb
@@ -2,9 +2,10 @@ require 'test_helper'
 
 class StatusesTest < Minitest::Test
 
-  def test_placed
-    assert_equal 'placed', Status.placed
-    assert_equal 'synced', Status.synced
+  def test_normal_statuses
+    %w( pending accepted declined placed synced ).each do |status|
+      assert_equal status.to_s, Status.send(status)
+    end
   end
 
   def test_icims_placed

--- a/test/models/run_test.rb
+++ b/test/models/run_test.rb
@@ -19,6 +19,7 @@ class RunTest < Minitest::Test
   end
 
   def test_available_positions
+    Position.destroy_all
     r = Run.new
     p = Position.create!
     r.add_to_available p


### PR DESCRIPTION
We disabled Airbrake on the Relay app during testing, adding it back in now.

Delegating more placement-related queries to Placement, accessing them as named scopes through Run.